### PR TITLE
Weekly reporting template

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,8 @@
                  [cheshire "5.7.0"]
                  [org.clojure/tools.cli "0.3.5"]
                  [commons-codec/commons-codec "1.10"]
-                 [enlive "1.1.6"]]
+                 [enlive "1.1.6"]
+                 [clj-time "0.13.0"]]
   :plugins [[cider/cider-nrepl "0.14.0"]
             [refactor-nrepl "2.2.0"]]
 

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
                  [clj-http "2.3.0"]
                  [cheshire "5.7.0"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [commons-codec/commons-codec "1.10"]]
+                 [commons-codec/commons-codec "1.10"]
+                 [enlive "1.1.6"]]
   :plugins [[cider/cider-nrepl "0.14.0"]
             [refactor-nrepl "2.2.0"]]
 

--- a/src/templates/weekly.html
+++ b/src/templates/weekly.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>not used</title>
+    <title>Remember to sanity check and edit</title>
   </head>
   <body>
     <b>To:</b> <span id="to">Test Cloud PM Team &lt;test-cloud-pm@microsoft.com&gt;; Simina Pasat &lt;siminap@microsoft.com&gt;; Villars Gimm &lt;vigimm@microsoft.com&gt;; Karl Piteira &lt;kapiteir@microsoft.com&gt;</span><br>
     <b>cc:</b> <span id="cc">Jakub Oleksy &lt;jakubo@exchange.microsoft.com&gt;; Test Cloud All &lt;test-cloud-all@microsoft.com&gt;; Mobile Center - Commerce Team &lt;mobile-center-commer@microsoft.com&gt;; Mobile Center - Auto Provisioning Team &lt;mobile-center-autopr@microsoft.com&gt;</span><br>
-    <b>Title: </b><span id="title">Eng. status June 5th, 2017: Auto Provisioning, Azure Billing, Test Cloud</span>
+    <b>Title: </b>Eng. status <span id="title-date">2017-06-05</span>: Auto Provisioning, Azure Billing, Test Cloud
     <h3>Engineering status</h3>
     <p>This provides a raw draft status which is used as input for the weekly status sent by PMs.<br>
       Justin send status for: Test Cloud<br>
@@ -77,11 +77,23 @@
         </ol>
       <p><b>This week (~5 select items)</b>
         <ol id="this-week">
-          <li>X</li>
-          <li>X</li>
-          <li>X</li>
-          <li>X</li>
-          <li>X</li>
+          <li>
+            <a href="https://msmobilecenter.visualstudio.com/Project-100/Auto-Provisioning/_workitems?id=7417&fullScreen=true&_a=edit">Auto Provisioning MVP: backend for sun-shine auto-provisioning with transient storage</a> [Chris, Aaron, Ramon]
+          </li>
+          <li>
+            <a href="https://msmobilecenter.visualstudio.com/Project-100/_workitems?id=4081&_a=edit&fullScreen=true">Research & document scenarios that use apple secrets</a> [Søren]
+          </li>
+          <li><a href="https://msmobilecenter.visualstudio.com/Project-100/_workitems?id=6865&_a=edit&fullScreen=true">Billing service REST API</a> – SPIKE to get API deployed in INT: fake data [Bjørn, Tomasz]</li>
+          <li>Billing service: Software infrastructure stand-up (<a href="https://msmobilecenter.visualstudio.com/Project-100/Azure-Billing/_workitems?id=6864&fullScreen=true&_a=edit">CosmosDB</a>,
+            <a href="https://msmobilecenter.visualstudio.com/Project-100/Azure-Billing/_workitems?id=6866&fullScreen=true&_a=edit">Worker role</a>) [Jon, Tomasz]</li>
+          <li>Live-site post-mort action items [Kasper, Ole, Christof, Søren]
+            <ul>
+              <li><a href="https://microsoft.sharepoint.com/teams/mobiledevops70/_layouts/OneNote.aspx?id=%2Fteams%2Fmobiledevops70%2FSiteAssets%2FMobile%20Dev%20Ops%20Notebook&wd=target%28Engineering%2FLiveSite%2FIncidents.one%7C81492FA7-B4EC-4E9B-ABFD-95085C239C1B%2F17-05-30%20%5BICM%3A%2038579535%5D%20Test%20cloud%20status%20endpoints%7CE2D924BE-7419-494C-BFD2-6919D2E3836E%2F%29">17-05-30 [ICM: 38579535] Test cloud status endpoints are unavailable </a>
+              </li>
+              <li><a href="https://microsoft.sharepoint.com/teams/mobiledevops70/_layouts/OneNote.aspx?id=%2Fteams%2Fmobiledevops70%2FSiteAssets%2FMobile%20Dev%20Ops%20Notebook&wd=target%28Engineering%2FLiveSite%2FIncidents.one%7C81492FA7-B4EC-4E9B-ABFD-95085C239C1B%2F17-06-02%20%5BICM%3A%2038846639%5D%20Some%20Mobile%20Center%20tests%7C3085983C-C38A-43A0-B219-005F2692971F%2F%29">17-06-02 [ICM: 38846639] Some Mobile Center tests not started successfully</a></li>
+          </li>
+
+          <li><a href="https://msmobilecenter.visualstudio.com/Test/_workitems?id=6604&_a=edit&fullScreen=true">Support sales to Audi Lighthouse: codesign issue for MyAudi</a> [Simon]</li>
         </ol>
     </section>
   </body>

--- a/src/templates/weekly.html
+++ b/src/templates/weekly.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>not used</title>
+  </head>
+  <body>
+    <b>To:</b> <span id="to">Test Cloud PM Team &lt;test-cloud-pm@microsoft.com&gt;; Simina Pasat &lt;siminap@microsoft.com&gt;; Villars Gimm &lt;vigimm@microsoft.com&gt;; Karl Piteira &lt;kapiteir@microsoft.com&gt;</span><br>
+    <b>cc:</b> <span id="cc">Jakub Oleksy &lt;jakubo@exchange.microsoft.com&gt;; Test Cloud All &lt;test-cloud-all@microsoft.com&gt;; Mobile Center - Commerce Team &lt;mobile-center-commer@microsoft.com&gt;; Mobile Center - Auto Provisioning Team &lt;mobile-center-autopr@microsoft.com&gt;</span><br>
+    <b>Title: </b><span id="title">Eng. status June 5th, 2017: Auto Provisioning, Azure Billing, Test Cloud</span>
+    <h3>Engineering status</h3>
+    <p>This provides a raw draft status which is used as input for the weekly status sent by PMs.<br>
+      Justin send status for: Test Cloud<br>
+      No standalone status is sent for: Auto-Provisioning, Azure Billing
+    <p>
+      <b>VSTS Backlogs</b><br>
+      <a href="https://msmobilecenter.visualstudio.com/Test/_backlogs/board/Stories">
+        Test Cloud</a><br>
+      <a href="https://msmobilecenter.visualstudio.com/Project-100/Auto-Provisioning/_backlogs/board/Stories">
+        Auto-Provisioning</a><br>
+      <a href="https://msmobilecenter.visualstudio.com/Project-100/Azure-Billing/_backlogs/board/Stories">
+        Azure Billing</a><br>
+
+    <p><b>Key Objectives for Next Two Months</b>
+      <ul id="key-objectives-static">
+        <li>Plan technical solution for Secure Credentials Storage for Auto Provisioning
+          <table>
+            <tr>
+              <td>Target Date:</td>
+              <td><b>June 12th</b></td>
+            </tr>
+            <tr>
+              <td>Confidence:</td>
+              <td><b>Medium</b></td>
+            </tr>
+          </table>
+          <p>Reduce uncertainty:
+            <ul>
+              <li>Coordinate and get agreement across all stake holders</li>
+            </ul>
+            <br>
+        </li>
+
+        <li>Test Cloud Security improvements roadmap
+          <table>
+            <tr>
+              <td>Target Date:</td>
+              <td><b>June 15th</b></td>
+            </tr>
+            <tr>
+              <td>Confidence:</td>
+              <td><b>High</b></td>
+            </tr>
+            <tr>
+              <td><a href="https://msmobilecenter.visualstudio.com/Test/_workitems?id=3732&_a=edit&fullScreen=true">VSTS Story</a></td>
+            </tr>
+          </table>
+      </ul>
+      <ul id="key-objectives-vsts">
+        <li><i>Auto Provisioning MVP (without secrets storage):</i><table><tr><td>Target Date</td><td><b>August 3rd</b></td></tr><tr><td>Confidence</td><td><b>Medium</b></td></tr></table><p>Reduce uncertainty by:</p><ul><li>bla bla bla</li></ul><p><a href=\"https://msmobilecenter.visualstudio.com/Project-100/_workitems?id=7417&amp;_a=edit&amp;fullScreen=true\"></a></p><br /></li>
+
+      </ul>
+
+    <p><b>Telemetry:</b> [PMs to report]
+
+    <p><b>
+        Risks & Notices</b><br>
+      <ol>
+        <li>
+          Windows support: Given past history of the windows automation team, we have low confidence in the quality of the bits provided by the team. We have included this in our "Plan for a plan", but this item will likely remain as a risk to windows support "this year".
+      </ol>
+    <p><b>Last week (~5 select items)</b>
+      <ol>
+        <li>X
+        <li>X
+        <li>X
+        <li>X
+        <li>X
+      </ol>
+    <p><b>This week (~5 select items)</b>
+      <ol>
+        <li>X
+        <li>X
+        <li>X
+        <li>X
+        <li>X
+      </ol>
+
+
+  </body>
+</html>

--- a/src/templates/weekly.html
+++ b/src/templates/weekly.html
@@ -39,7 +39,6 @@
             </ul>
             <br>
         </li>
-
         <li>Test Cloud Security improvements roadmap
           <table>
             <tr>
@@ -54,6 +53,7 @@
               <td><a href="https://msmobilecenter.visualstudio.com/Test/_workitems?id=3732&_a=edit&fullScreen=true">VSTS Story</a></td>
             </tr>
           </table>
+        </li>
       </ul>
       <ul id="key-objectives-vsts">
         <li><i>Auto Provisioning MVP (without secrets storage):</i><table><tr><td>Target Date</td><td><b>August 3rd</b></td></tr><tr><td>Confidence</td><td><b>Medium</b></td></tr></table><p>Reduce uncertainty by:</p><ul><li>bla bla bla</li></ul><p><a href=\"https://msmobilecenter.visualstudio.com/Project-100/_workitems?id=7417&amp;_a=edit&amp;fullScreen=true\"></a></p><br /></li>
@@ -62,29 +62,27 @@
 
     <p><b>Telemetry:</b> [PMs to report]
 
-    <p><b>
-        Risks & Notices</b><br>
+    <p><b>Risks & Notices</b><br>
       <ol>
-        <li>
-          Windows support: Given past history of the windows automation team, we have low confidence in the quality of the bits provided by the team. We have included this in our "Plan for a plan", but this item will likely remain as a risk to windows support "this year".
+        <li> Windows support: Given past history of the windows automation team, we have low confidence in the quality of the bits provided by the team. We have included this in our "Plan for a plan", but this item will likely remain as a risk to windows support "this year".</li>
       </ol>
-    <p><b>Last week (~5 select items)</b>
-      <ol>
-        <li>X
-        <li>X
-        <li>X
-        <li>X
-        <li>X
-      </ol>
-    <p><b>This week (~5 select items)</b>
-      <ol>
-        <li>X
-        <li>X
-        <li>X
-        <li>X
-        <li>X
-      </ol>
-
-
+    <section id="weekly-progress">
+      <p><b>Last week (~5 select items)</b>
+        <ol id="last-week">
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+        </ol>
+      <p><b>This week (~5 select items)</b>
+        <ol id="this-week">
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+          <li>X</li>
+        </ol>
+    </section>
   </body>
 </html>

--- a/src/vsts_work_migrate/cli.clj
+++ b/src/vsts_work_migrate/cli.clj
@@ -16,6 +16,7 @@
     dump-from-mseng             - Dump (and pretty print) WIQL query results from MSEng instance. Arguments: <wiql-file-path> <mappings.json> <dump-file-path>
     copy-to-msmobilecenter      - Copy WIQL query result to msmobilecenter. Arguments: <dump-file-path> <Project> <saved-results-output-path>
     delete-from-msmobilecenter  - Delete previously copied work-items from msmobilecenter (i.e. \"undo\" creation). Arguments: <saved-results-output-path>.
+    weekly-email                - Save a weekly email from template. Arguments: <input-template-path>  <saved-output-path> <VSTS work item ids>.
     ")))
 
 
@@ -23,7 +24,7 @@
   [["-h" "--help"]
    ["-d" "--dry-run"]])
 
-(declare dump-from-mseng copy-to-msmobilecenter delete-from-msmobilecenter)
+(declare dump-from-mseng copy-to-msmobilecenter delete-from-msmobilecenter weekly-email)
 
 (defn -main
   [& args]
@@ -53,6 +54,7 @@
         "dump-from-mseng" (dump-from-mseng options (rest arguments))
         "copy-to-msmobilecenter" (copy-to-msmobilecenter options (rest arguments))
         "delete-from-msmobilecenter" (delete-from-msmobilecenter options (rest arguments))
+        "weekly-email" (weekly-email options (rest arguments))
         (binding [*out* *err*]
           (println "** No such tool:" (first arguments))
           (dump-usage summary)
@@ -134,3 +136,20 @@
                                             true)
                          options)]
       (println "Done deleting items"))))
+
+(defn to-integer [s]
+  (try
+    (Integer/parseInt s 10)
+    (catch Exception e
+      nil)))
+
+(defn weekly-email
+  [options args]
+  (let [input-template (first args)
+        output-file (second args)
+        ids (map to-integer (take-while to-integer (rest (rest args))))]
+    (core/template cfg/msmobilecenter-instance
+                   input-template
+                   ids
+                   output-file
+                   options)))

--- a/src/vsts_work_migrate/core.clj
+++ b/src/vsts_work_migrate/core.clj
@@ -101,7 +101,7 @@
         (println "DRY RUN: Not deleting item" id)))))
 
 (defn template
-  [instance work-item-ids options]
+  [instance input-template work-item-ids output-file options]
   (let [items (api/get-work-items instance work-item-ids)
         view-model (map wi-helpers/view-model (:value items))]
     (println "View model for work items: " work-item-ids)
@@ -109,6 +109,6 @@
     (if-not (:dry-run options)
       (do
         (println "Printing template for work-items" work-item-ids)
-        (spit (:output-file options) (apply str (template/main-template view-model)))
-        (println "Wrote result to " (:output-file options)))
+        (spit output-file (apply str (template/run-template input-template view-model)))
+        (println "Wrote result to " output-file))
       (println "DRY RUN: Not writing file"))))

--- a/src/vsts_work_migrate/core.clj
+++ b/src/vsts_work_migrate/core.clj
@@ -6,6 +6,7 @@
              [vsts-work-migrate.vsts-api :as api]
              [vsts-work-migrate.mappings :as mappings]
              [vsts-work-migrate.helpers :as wi-helpers]
+             [vsts-work-migrate.template :as template]
              [cheshire.core :as json]))
 
 (defn query-work-items
@@ -98,3 +99,16 @@
         (api/delete-work-item instance id))
       (do
         (println "DRY RUN: Not deleting item" id)))))
+
+(defn template
+  [instance work-item-ids options]
+  (let [items (api/get-work-items instance work-item-ids)
+        view-model (map wi-helpers/view-model (:value items))]
+    (println "View model for work items: " work-item-ids)
+    (clojure.pprint/pprint view-model)
+    (if-not (:dry-run options)
+      (do
+        (println "Printing template for work-items" work-item-ids)
+        (spit (:output-file options) (apply str (template/main-template view-model)))
+        (println "Wrote result to " (:output-file options)))
+      (println "DRY RUN: Not writing file"))))

--- a/src/vsts_work_migrate/core.clj
+++ b/src/vsts_work_migrate/core.clj
@@ -103,12 +103,19 @@
 (defn template
   [instance input-template work-item-ids output-file options]
   (let [items (api/get-work-items instance work-item-ids)
-        view-model (map wi-helpers/view-model (:value items))]
-    (println "View model for work items: " work-item-ids)
+        view-model (map wi-helpers/view-model (:value items))
+        weekly-items (api/get-work-items instance
+                                         (get options :weekly-items []))
+        weekly-items-view-model (map wi-helpers/view-model (:value weekly-items))]
+    (println "View model for main work items: " work-item-ids)
     (clojure.pprint/pprint view-model)
+
+    (println "View model for weekly work items: " (get options :weekly-items []))
+    (clojure.pprint/pprint weekly-items-view-model)
+
     (if-not (:dry-run options)
       (do
         (println "Printing template for work-items" work-item-ids)
-        (spit output-file (apply str (template/run-template input-template view-model)))
+        (spit output-file (apply str (template/run-template input-template view-model weekly-items-view-model)))
         (println "Wrote result to " output-file))
       (println "DRY RUN: Not writing file"))))

--- a/src/vsts_work_migrate/helpers.clj
+++ b/src/vsts_work_migrate/helpers.clj
@@ -145,13 +145,19 @@
   (let [team-project (get-system-field work-item :TeamProject)
         target-date-time (get-in work-item [:fields
                                             :Microsoft.VSTS.Scheduling.TargetDate])
-        target-date (first (clojure.string/split target-date-time #"T"))
+        target-date  (and target-date-time
+                          (first (clojure.string/split target-date-time #"T")))
         html-url (str "https://msmobilecenter.visualstudio.com/"
                       team-project
                       "/_workitems?id="
                       (:id work-item)
-                      "&_a=edit&fullScreen=true")]
+                      "&_a=edit&fullScreen=true")
+
+        assigned-to (get-system-field work-item :AssignedTo)
+        assigned-to-firstname (first (clojure.string/split assigned-to #" "))]
     {:title (get-system-field work-item :Title)
      :target-date target-date
      :confidence (get-in work-item [:fields :Simpleagileprocess.CloseDateConfidence])
+     :assigned-to assigned-to
+     :assigned-to-firstname assigned-to-firstname
      :vsts-link html-url}))

--- a/src/vsts_work_migrate/helpers.clj
+++ b/src/vsts_work_migrate/helpers.clj
@@ -140,3 +140,18 @@
                project
                (work-item-tree root grouped-by-parents)
                options))
+
+(defn view-model [work-item]
+  (let [team-project (get-system-field work-item :TeamProject)
+        target-date-time (get-in work-item [:fields
+                                            :Microsoft.VSTS.Scheduling.TargetDate])
+        target-date (first (clojure.string/split target-date-time #"T"))
+        html-url (str "https://msmobilecenter.visualstudio.com/"
+                      team-project
+                      "/_workitems?id="
+                      (:id work-item)
+                      "&_a=edit&fullScreen=true")]
+    {:title (get-system-field work-item :Title)
+     :target-date target-date
+     :confidence (get-in work-item [:fields :Simpleagileprocess.CloseDateConfidence])
+     :vsts-link html-url}))

--- a/src/vsts_work_migrate/template.clj
+++ b/src/vsts_work_migrate/template.clj
@@ -1,0 +1,41 @@
+(ns vsts-work-migrate.template
+  (:require [net.cgrand.enlive-html :as html]))
+
+(def ^:dynamic *dummy-objectives*
+     {:title "Enlive Template2 Tutorial"
+      :work-items [{:title "Auto Provisioning MVP (without secrets storage)"
+                    :target-date "August 3rd"
+                    :confidence "Medium"
+                    :vsts-link "https://msmobilecenter.visualstudio.com/Project-100/_workitems?id=7417&_a=edit&fullScreen=true"}]})
+
+
+(def ^:dynamic *objective-sel*
+  [[:#key-objectives-vsts] :> html/first-child])
+
+(html/defsnippet objective "templates/weekly.html" *objective-sel*
+  [{:keys [title target-date confidence vsts-link]}]
+  [:li]
+  (html/content
+   (html/html
+    [:i (str title ":")]
+    [:table
+     [:tr
+      [:td "Target Date:"]
+      [:td [:b target-date]]]
+     [:tr
+      [:td "Confidence:"]
+      [:td [:b confidence]]]]
+    [:span "Reduce uncertainty by:"]
+    [:ul [:li "bla bla bla"]]
+    [:span [:a {:href vsts-link} "VSTS work-item"]]
+    [:br]
+    [:br])))
+
+(defn today []
+  (str (java.util.Date.)))
+
+(html/deftemplate main-template "templates/weekly.html"
+  [objectives]
+  [:span#title] (html/content "Eng. status " (today) ": Auto Provisioning, Azure Billing, Test Cloud")
+  [:ul#key-objectives-vsts]
+  (html/content (map #(objective %) objectives)))

--- a/src/vsts_work_migrate/template.clj
+++ b/src/vsts_work_migrate/template.clj
@@ -42,21 +42,31 @@
 
 (html/deftemplate main-template "templates/weekly.html"
   [objectives]
-  [:span#title] (html/content "Eng. status "
-                              (format/unparse (format/formatters :year-month-day) (on-monday))
-                              ": Auto Provisioning, Azure Billing, Test Cloud")
+
   [:ul#key-objectives-vsts]
   (html/content (map #(objective %) objectives)))
 
 (defn run-template
-  [input-template objectives]
+  [input-template objectives this-week-items]
   (let [my-template
         (html/template
           input-template
-          [objectives]
+          [objectives this-week-items]
+          [:span#title-date]
+          (html/content
+           (format/unparse (format/formatters :year-month-day) (on-monday)))
+
           [:#key-objectives-vsts]
           (html/content (map #(objective %) objectives))
+
           [:#weekly-progress]
           (html/move [[:#this-week] :> :li] [:#last-week] html/content)
-          [:#this-week] (html/content (html/html [:li])))]
-    (my-template objectives)))
+          [:#this-week] (html/content
+                         (html/html
+                          (map
+                           (fn [weekly]
+                             [:li
+                              [:a {:href (:vsts-link weekly)} (:title weekly)]
+                              [:span (str " [" (:assigned-to-firstname weekly) "]")]])
+                           this-week-items))))]
+    (my-template objectives this-week-items)))

--- a/weekly-email-example.sh
+++ b/weekly-email-example.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./vsts-migrate weekly-email src/templates/weekly.html output.html 7597 3827 --weekly-items 4081,6865,6604,7417


### PR DESCRIPTION
Adds a command to produce a weekly email from a template or a previous weekly email.

```
weekly-email                - Save a weekly email from template. Arguments: <input-template-path>  <saved-output-path> <VSTS work item ids>.
```

Example usage:
```
./vsts-migrate weekly-email src/templates/weekly.html output.html 7597 3827 --weekly-items 4081,6865,6604,7417
```